### PR TITLE
refactor(styles): use "/bower_component" instead of "../bower_component"

### DIFF
--- a/src/bootstrap-additions.less
+++ b/src/bootstrap-additions.less
@@ -1,4 +1,4 @@
-@import (reference) "../bower_components/bootstrap/less/bootstrap";
+@import (reference) "/bower_components/bootstrap/less/bootstrap";
 @import "alert/alert";
 @import "aside/aside";
 @import "callout/callout";


### PR DESCRIPTION
It would be very useful in the case if you try to include "bootstrap-additions.less" (via `@import "/bower_components/bootstrap-additions/src/bootstrap-additions";`) into your LESS-file instead of referencing CSS directly.

Currently you will get:

```
error: '../bower_components/bootstrap/less/bootstrap.less' wasn't found in file bower_components/bootstrap-additions/src/bootstrap-additions.less line no. 1
```