### PR TITLE
webpack/less-loader compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,11 @@ var config = require('ng-factory').use(gulp, {
   },
   bower: {
     exclude: /jquery|js\/bootstrap|\.less/
+  },
+  less: {
+    globalVars: {
+      componentsDir: '\'bower_components/\''
+    }
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {},
   "devDependencies": {
     "del": "^1.2.0",
-    "factory-angular-channels": "^0.7.1",
+    "factory-angular-channels": "^0.9.0",
     "gulp": "gulpjs/gulp#4.0",
-    "ng-factory": "^1.0",
+    "ng-factory": "^1.1.0",
     "undertaker-lib-tasks": "^0.3.1"
   },
   "engines": {

--- a/src/alert/alert.less
+++ b/src/alert/alert.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Alerts placement

--- a/src/aside/aside.less
+++ b/src/aside/aside.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Aside element

--- a/src/bootstrap-additions.less
+++ b/src/bootstrap-additions.less
@@ -1,3 +1,5 @@
+@componentsDir: "bower_components/";
+
 @import "alert/alert";
 @import "aside/aside";
 @import "callout/callout";

--- a/src/callout/callout.less
+++ b/src/callout/callout.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Callouts

--- a/src/datepicker/datepicker.less
+++ b/src/datepicker/datepicker.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Datepicker element

--- a/src/modal/modal.less
+++ b/src/modal/modal.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 // Support center placement
 .modal {

--- a/src/popover/popover.less
+++ b/src/popover/popover.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Popovers corner placement

--- a/src/timepicker/timepicker.less
+++ b/src/timepicker/timepicker.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Timepicker element

--- a/src/tooltip/tooltip.less
+++ b/src/tooltip/tooltip.less
@@ -1,4 +1,4 @@
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import (optional, reference) "@{componentsDir}bootstrap/less/bootstrap";
 
 /*
  * Fancy tooltips


### PR DESCRIPTION
As developer I would like to use `bootstrap-additions` with `webpack` via `less-loader` and this PR helps override `componentsDir` via `less-loader`:

``` js
{
    globalVars: {
      componentsDir: '\'~/\''
    }
}
```
